### PR TITLE
Add help option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,3 @@ $ yarn site:dev
 - Verbose option in CLI
 - Show configuration of screenshot in result report
 - No result report (json output only) mode
-- Friendly CLI help

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,28 @@ import { copy, ensureDir } from "fs-extra";
 
 export type EnantiomCliArgument = {
   config: string;
+  help?: boolean;
 };
 
-const args = parse<EnantiomCliArgument>({
-  config: { type: String, alias: "c" },
-});
+const args = parse<EnantiomCliArgument>(
+  {
+    config: { type: String, alias: "c", description: "Path to config file" },
+    help: {
+      type: Boolean,
+      optional: true,
+      alias: "h",
+      description: "Prints this usage guide",
+    },
+  },
+  {
+    helpArg: "help",
+    headerContentSections: [
+      {
+        header: "enantiom CLI",
+      },
+    ],
+  }
+);
 
 const OUTPUT_DIRNAME = join("public", "assets");
 


### PR DESCRIPTION
```
$ yarn dev -h
yarn run v1.22.10
$ run-s clean
$ del-cli src/**/*.{js,jsx}
$ ts-node src/index.ts -h

enantiom CLI

Options

  -c, --config string   Path to config file     
  -h, --help            Prints this usage guide 
```